### PR TITLE
Update Rubocop for Ruby 2.4

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ AllCops:
     - db/migrate/**/*
     - db/schema.rb
   DisplayCopNames: true
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.4
 
 Documentation:
   Enabled: false
@@ -33,3 +33,15 @@ Style/SpaceInsideBlockBraces:
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/RedundantFreeze:
+  Enabled: false
+
+Style/VariableNumber:
+  EnforcedStyle: snake_case
+
+Style/NumericPredicate:
+  EnforcedStyle: comparison

--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ group :development, :test do
   gem "capybara"
   gem "rails-controller-testing"
   gem "rspec-rails", "~> 3.4"
-  gem "rubocop", "= 0.36"
+  gem "rubocop", "= 0.43"
   gem "awesome_print"
   gem "pry-byebug"
   gem "dotenv"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,10 +188,10 @@ GEM
       activerecord (>= 3.0, < 6.0)
       activesupport (>= 3.0, < 6.0)
       request_store (~> 1.1)
-    parser (2.5.1.0)
+    parser (2.5.1.2)
       ast (~> 2.4.0)
     pg (0.21.0)
-    powerpack (0.1.1)
+    powerpack (0.1.2)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -279,13 +279,14 @@ GEM
       rspec-mocks (~> 3.7.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
-    rubocop (0.36.0)
-      parser (>= 2.3.0.0, < 3.0)
+    rubocop (0.43.0)
+      parser (>= 2.3.1.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-ole (1.2.12.1)
-    ruby-progressbar (1.9.0)
+    ruby-progressbar (1.10.0)
     sass (3.5.6)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -340,6 +341,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
+    unicode-display_width (1.4.0)
     warden (1.2.7)
       rack (>= 1.0)
     web-console (2.3.0)
@@ -393,7 +395,7 @@ DEPENDENCIES
   rails_12factor
   rake (~> 11.2)
   rspec-rails (~> 3.4)
-  rubocop (= 0.36)
+  rubocop (= 0.43)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   select2-rails
@@ -411,4 +413,4 @@ RUBY VERSION
    ruby 2.4.4p296
 
 BUNDLED WITH
-   1.16.1
+   1.16.6

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def show_detailed_exceptions?
-    current_user.show_detailed_exceptions? if current_user
+    current_user&.show_detailed_exceptions?
   end
 
   private
@@ -18,7 +18,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_profiler_access
-    if current_user && current_user.can_view_profiler_results? && Profiler.enabled?(session)
+    if current_user&.can_view_profiler_results? && Profiler.enabled?(session)
       Rack::MiniProfiler.authorize_request
     else
       Rack::MiniProfiler.deauthorize_request

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -31,7 +31,7 @@ class ItemsController < ApplicationController
   def update # rubocop:disable Metrics/AbcSize
     @item = Item.find(params[:id])
     item_params = params.require(:item).permit(:description, :current_quantity, :category_id, :sku, :value)
-    item_params[:value].delete!(",") if item_params[:value]
+    item_params[:value]&.delete!(",")
     item_event_params = params.require(:item).permit(:edit_amount, :edit_method, :edit_reason, :edit_source)
 
     @item.assign_attributes item_params

--- a/app/helpers/reconciliations_helper.rb
+++ b/app/helpers/reconciliations_helper.rb
@@ -1,8 +1,23 @@
 module ReconciliationsHelper
   def reconciliation_delta_table_row(delta)
-    link_to_sheet = inventory_reconciliation_count_sheet_path(delta.reconciliation, delta.warning_count_sheet_id)
-    href_data = delta.warning_count_sheet_id ? { href: link_to_sheet } : {}
-    data = { toggle: "tooltip", placement: "top", title: delta.warning_text }.merge(href_data)
-    tag(:tr, class: delta.row_css_class, data: data)
+    data = { toggle: "tooltip", placement: "top", title: delta.warning_text }
+
+    if delta.warning_count_sheet_id
+      data[:href] = inventory_reconciliation_count_sheet_path(delta.reconciliation, delta.warning_count_sheet_id)
+    end
+
+    content_tag(:tr, class: delta.row_css_class, data: data) do
+      yield
+    end
+  end
+
+  def changed_amount_icon(delta)
+    return unless delta.changed_amount?
+
+    if delta.changed_amount > 0
+      tag(:i, class: "glyphicon glyphicon-triangle-top")
+    else
+      tag(:i, class: "glyphicon glyphicon-triangle-bottom")
+    end
   end
 end

--- a/app/helpers/reconciliations_helper.rb
+++ b/app/helpers/reconciliations_helper.rb
@@ -1,0 +1,8 @@
+module ReconciliationsHelper
+  def reconciliation_delta_table_row(delta)
+    link_to_sheet = inventory_reconciliation_count_sheet_path(delta.reconciliation, delta.warning_count_sheet_id)
+    href_data = delta.warning_count_sheet_id ? { href: link_to_sheet } : {}
+    data = { toggle: "tooltip", placement: "top", title: delta.warning_text }.merge(href_data)
+    tag(:tr, class: delta.row_css_class, data: data)
+  end
+end

--- a/app/models/backup.rb
+++ b/app/models/backup.rb
@@ -50,7 +50,7 @@ class Backup
 
   def close
     @response.stream.close if @response
-    @tempfile.close! if @tempfile
+    @tempfile&.close!
   end
 
   private

--- a/app/models/concerns/users/info.rb
+++ b/app/models/concerns/users/info.rb
@@ -106,7 +106,7 @@ module Users
 
     def role_at(organization)
       org_user = organization_user_at(organization)
-      org_user.role if org_user
+      org_user&.role
     end
   end
 end

--- a/app/models/count_sheet.rb
+++ b/app/models/count_sheet.rb
@@ -78,8 +78,7 @@ class CountSheet < ApplicationRecord
   end
 
   def final_counts_present_on_complete
-    if complete && count_sheet_details.any? { |x| x.final_count.blank? }
-      errors.add(:count_sheet_details, "must have final values on complete")
-    end
+    error = "must have final values on complete"
+    errors.add(:count_sheet_details, error) if complete && count_sheet_details.any? { |x| x.final_count.blank? }
   end
 end

--- a/app/models/drive_backup.rb
+++ b/app/models/drive_backup.rb
@@ -26,7 +26,8 @@ class DriveBackup
   def authorization
     @authorization ||= Google::Auth::ServiceAccountCredentials.make_creds(
       json_key_io: StringIO.new(google_config.service_account_json),
-      scope: "https://www.googleapis.com/auth/drive")
+      scope: "https://www.googleapis.com/auth/drive"
+    )
   end
 
   def drive_service

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -35,7 +35,7 @@ class Export
 
   def close
     @response.stream.close if @response
-    @tempfile.close! if @tempfile
+    @tempfile&.close!
   end
 
   def filename

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -98,7 +98,7 @@ class Item < ApplicationRecord
   end
 
   def requested_quantity
-    raise "Cannot retrieve requested_quantity unless it is set first!" unless @requested_quantity || all_loaded
+    raise "Cannot retrieve requested_quantity unless it is set first!" unless @requested_quantity || all_loaded?
     @requested_quantity ||= requested_orders.map(&:order_details).flatten.select { |x| x.item_id == id }.sum(&:quantity)
   end
 
@@ -169,7 +169,7 @@ class Item < ApplicationRecord
     end
   end
 
-  def all_loaded
+  def all_loaded?
     requested_orders.loaded? && requested_orders.all? { |order| order.order_details.loaded? }
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -98,14 +98,8 @@ class Item < ApplicationRecord
   end
 
   def requested_quantity
-    @requested_quantity ||=
-      begin
-        if requested_orders.loaded? && requested_orders.all? { |order| order.order_details.loaded? }
-          requested_orders.map(&:order_details).flatten.select { |x| x.item_id == id }.sum(&:quantity)
-        else
-          raise "Cannot retrieve requested_quantity unless it is set first!"
-        end
-      end
+    raise "Cannot retrieve requested_quantity unless it is set first!" unless @requested_quantity || all_loaded
+    @requested_quantity ||= requested_orders.map(&:order_details).flatten.select { |x| x.item_id == id }.sum(&:quantity)
   end
 
   def available_quantity
@@ -173,5 +167,9 @@ class Item < ApplicationRecord
     when "new_total"
       self.current_quantity = edit_amount
     end
+  end
+
+  def all_loaded
+    requested_orders.loaded? && requested_orders.all? { |order| order.order_details.loaded? }
   end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -71,12 +71,12 @@ class Organization < ApplicationRecord
 
   def add_county
     return if county.present? || primary_address.blank?
-    if changed_attributes.keys.include?("addresses_attributes")
-      fetch_geocoding_data do |result|
-        self.county = result.address_components.find { |component|
-          component["types"].include?("administrative_area_level_2")
-        }["short_name"]
-      end
+    return unless changed_attributes.keys.include?("addresses_attributes")
+
+    fetch_geocoding_data do |result|
+      self.county = result.address_components.find { |component|
+        component["types"].include?("administrative_area_level_2")
+      }["short_name"]
     end
   end
 

--- a/app/models/reconciliation_deltas.rb
+++ b/app/models/reconciliation_deltas.rb
@@ -90,12 +90,7 @@ class ReconciliationDeltas
 
     def changed_amount_icon
       return unless changed_amount?
-
-      if changed_amount > 0
-        %(<i class="glyphicon glyphicon-triangle-top"></i>).html_safe
-      else
-        %(<i class="glyphicon glyphicon-triangle-bottom"></i>).html_safe
-      end
+      changed_amount > 0 ? "top" : "bottom"
     end
   end
 
@@ -164,13 +159,6 @@ class ReconciliationDeltas
       @counts += 1
     end
 
-    def warning_path
-      return unless @warning_count_sheet_id
-      path = Rails.application.routes.url_helpers
-                  .inventory_reconciliation_count_sheet_path(reconciliation, @warning_count_sheet_id)
-      %(data-href="#{ERB::Util.html_escape path}").html_safe
-    end
-
     def no_count_sheets?
       counts == 0
     end
@@ -180,9 +168,7 @@ class ReconciliationDeltas
       texts << "This item has incomplete count sheets." if includes_incomplete_sheet
       texts << "This item has final counts that aren't yet entered." if includes_missing_final_count
       texts << "This item has no count sheets!" if no_count_sheets?
-      return if texts.empty?
-      tooltip = texts.join(" ")
-      %(data-toggle="tooltip" data-placement="top" title="#{ERB::Util.html_escape tooltip}").html_safe
+      texts.join(" ")
     end
 
     def requested_quantity

--- a/app/models/reports/value_by_donor.rb
+++ b/app/models/reports/value_by_donor.rb
@@ -43,16 +43,16 @@ module Reports
       end
 
       def data
-        @data ||= donations.keys.sort_by { |item| item_descrtipion(item) }.map do |item|
+        @data ||= donations.keys.sort_by { |item| item_description(item) }.map do |item|
           item_donations = donations[item]
-          [item_descrtipion(item),
+          [item_description(item),
            item_donations.sum(&:quantity),
            item_donations.sum(&:total_value)]
         end
       end
 
-      def item_descrtipion(item)
-        item.try(:description).presence || "Unknown Item"
+      def item_description(item)
+        item&.description || "Unknown Item"
       end
     end
 

--- a/app/models/shipment.rb
+++ b/app/models/shipment.rb
@@ -4,7 +4,7 @@ class Shipment < ApplicationRecord
   enum shipping_carrier: { FedEx: 0, USPS: 1, UPS: 2, Hand: 3 }
 
   def self.valid_carriers
-    shipping_carriers.slice(*%w(FedEx USPS UPS))
+    shipping_carriers.slice("FedEx", "USPS", "UPS")
   end
 
   def tracking_url

--- a/app/models/spreadsheet_exporter.rb
+++ b/app/models/spreadsheet_exporter.rb
@@ -33,9 +33,9 @@ class SpreadsheetExporter
   class MasterInventory < SpreadsheetExporter
     def initialize
       super
-      sheet1 = create_sheet("All Items")
-      sheet1 << %w(Category Description Quantity\ On\ hand SKU Value)
-      fill_sheet_with_inventory(sheet1)
+      sheet_1 = create_sheet("All Items")
+      sheet_1 << %w(Category Description Quantity\ On\ hand SKU Value)
+      fill_sheet_with_inventory(sheet_1)
     end
 
     private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,11 +43,11 @@ class User < ApplicationRecord
 
   protected
 
-  def email_updated? # rubocop:disable Style/TrivialAccessors
+  def email_updated?
     @email_updated
   end
 
-  def password_updated? # rubocop:disable Style/TrivialAccessors
+  def password_updated?
     @password_updated
   end
 

--- a/app/models/user_invitation.rb
+++ b/app/models/user_invitation.rb
@@ -20,7 +20,7 @@ class UserInvitation < ApplicationRecord
 
   def already_member?
     user = User.find_by_email(email)
-    user && user.member_at?(organization)
+    user&.member_at?(organization)
   end
 
   def expired?

--- a/app/views/inventory_reconciliations/_incomplete_deltas.html.erb
+++ b/app/views/inventory_reconciliations/_incomplete_deltas.html.erb
@@ -19,17 +19,19 @@
 
       <tbody>
         <% @reconciliation.deltas.each do |delta| %>
-          <%= reconciliation_delta_table_row(delta) %>
-            <td class="<%= delta.description_css_class %>"><%= delta.item.category.description %> - <%= delta.item.description %></td>
+          <% reconciliation_delta_table_row(delta) do %>
+            <td class="<%= delta.description_css_class %>">
+              <%= delta.item.category.description %> - <%= delta.item.description %>
+            </td>
             <td><%= delta.requested_quantity %></td>
             <td><%= delta.current_quantity %></td>
             <td><%= delta.final_count %></td>
 
             <td class="<%= delta.changed_amount_css_class %>">
-              <%= tag(:i, class: "glyphicon glyphicon-triangle-#{delta.changed_amount_icon}") %>
+              <%= changed_amount_icon(delta) %>
               <%= delta.changed_amount %>
             </td>
-          </tr>
+          <% end %>
         <% end %>
       </tbody>
     </table>

--- a/app/views/inventory_reconciliations/_incomplete_deltas.html.erb
+++ b/app/views/inventory_reconciliations/_incomplete_deltas.html.erb
@@ -19,14 +19,14 @@
 
       <tbody>
         <% @reconciliation.deltas.each do |delta| %>
-          <tr class="<%= delta.row_css_class %>" <%= delta.warning_path %> <%= delta.warning_text %>>
+          <%= reconciliation_delta_table_row(delta) %>
             <td class="<%= delta.description_css_class %>"><%= delta.item.category.description %> - <%= delta.item.description %></td>
             <td><%= delta.requested_quantity %></td>
             <td><%= delta.current_quantity %></td>
             <td><%= delta.final_count %></td>
 
             <td class="<%= delta.changed_amount_css_class %>">
-              <%= delta.changed_amount_icon %>
+              <%= tag(:i, class: "glyphicon glyphicon-triangle-#{delta.changed_amount_icon}") %>
               <%= delta.changed_amount %>
             </td>
           </tr>

--- a/lib/tasks/exceptions.rake
+++ b/lib/tasks/exceptions.rake
@@ -9,7 +9,7 @@ namespace :exceptions do
       exceptions << k if k.ancestors.include?(Exception)
     end
 
-    puts exceptions.sort { |a, b| a.to_s <=> b.to_s }.join("\n")
+    puts exceptions.sort_by(&:to_s).join("\n")
   end
 
   task list_custom: :environment do
@@ -26,6 +26,6 @@ namespace :exceptions do
       exceptions << k if k.ancestors.include?(Exception) && !existing.include?(k)
     end
 
-    puts exceptions.sort { |a, b| a.to_s <=> b.to_s }.join("\n")
+    puts exceptions.sort_by(&:to_s).join("\n")
   end
 end


### PR DESCRIPTION
While working on Issue #529 , I received a Rubocop error when submitting a PR for that small change.  The current version of Rubocop is expecting the project to use Ruby 2.2, while this project is on Ruby 2.4.  I updated the Rubocop version to .43 to allow this change, and then ran into more errors.  I fixed some additional things, but disabled a couple rules in the config file because it ended up being a lot of changes that I felt may not provide much value.

The different things I fixed are in separate commits:
- [X] Update Rubocop version
- [X] Add safe navigation
- [X] Remove unnecessary inline Rubocop disables
- [X] Fix a parenthesis on wrong line
- [X] Standardize variable names with numbers (using snake case throughout project now)
- [X] Update sorting methods
- [X] Remove an unnecessary splat
- [X] Refactor some html from model and template into a helper
- [X] Add a few guard clauses to methods

The new rules I disabled:
- [Style/FrozenStringLiteralComment](https://rubocop.readthedocs.io/en/latest/cops_style/#stylefrozenstringliteralcomment)
- [Style/RedundantFreeze](https://rubocop.readthedocs.io/en/latest/cops_style/#styleredundantfreeze)