### PR TITLE
Fix ship_to_name not being saved

### DIFF
--- a/app/models/order_updater.rb
+++ b/app/models/order_updater.rb
@@ -7,10 +7,12 @@ class OrderUpdater
   end
 
   def update
+    return unless params[:order].present?
     update_notes
     update_details
     update_tracking_details
     update_address
+    update_ship_to_name
     update_status
   end
 
@@ -21,22 +23,27 @@ class OrderUpdater
   end
 
   def update_notes
-    return unless params[:order].present? && params[:order].include?(:notes)
+    return unless params[:order].include?(:notes)
     order.notes = params[:order][:notes]
   end
 
   def update_tracking_details
-    return unless params[:order].present? && params[:order][:tracking_details].present?
+    return unless params[:order][:tracking_details].present?
     order.add_tracking_details(params)
   end
 
   def update_address
-    return unless params[:order].present? && params[:order][:ship_to_address].present?
+    return unless params[:order][:ship_to_address].present?
     order.ship_to_address = params[:order][:ship_to_address]
   end
 
+  def update_ship_to_name
+    return unless params[:order][:ship_to_name].present?
+    order.ship_to_name = params[:order][:ship_to_name]
+  end
+
   def update_status
-    return unless params[:order].present? && params[:order][:status].present?
+    return unless params[:order][:status].present?
     order.update_status(params[:order][:status], params)
   end
 end


### PR DESCRIPTION
When you create an order the users name is saved as the ship_to_name. Except as a super_admin.

However you cannot edit the ship_to_name as it was never updated in the OrderUpdater.