### PR TITLE
[727] Upgrade puma to resolve compilation error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ group :production do
 end
 
 group :production, :staging, :review do
-  gem "puma"
+  gem "puma", "~> 4.3.6"
   gem "rails_12factor"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,7 +211,7 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (4.0.5)
-    puma (4.3.5)
+    puma (4.3.6)
       nio4r (~> 2.0)
     rack (2.2.3)
     rack-mini-profiler (0.10.7)
@@ -406,7 +406,7 @@ DEPENDENCIES
   pg (~> 0.18)
   pry-byebug
   pry-rails
-  puma
+  puma (~> 4.3.6)
   rack-mini-profiler (~> 0.10)
   rack-timeout
   rails (~> 5.1.7)


### PR DESCRIPTION
**Addresses**: [737](https://github.com/GratefulGarmentProject/StockAid/issues/737)

According to [Issue #2304](https://github.com/puma/puma/issues/2304) at puma/puma, the `ctype.h` header file was no being included.

This has been fixed at version 4.3.6.

**Modifications:**

- change Gemfile to specify at least version 4.3.6 for puma