### PR TITLE
[750] Order can be viewed by non-super-admins after submitted

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -34,6 +34,7 @@ class OrdersController < ApplicationController
     redirect_to edit_order_path(order)
   end
 
+  # rubocop:disable Metrics/AbcSize
   def edit
     @order = Order.includes(order_details: :item).find(params[:id])
 
@@ -47,6 +48,7 @@ class OrdersController < ApplicationController
       redirect_to orders_path
     end
   end
+  # rubocop:enable Metrics/AbcSize
 
   def update
     order = current_user.update_order params

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -34,21 +34,10 @@ class OrdersController < ApplicationController
     redirect_to edit_order_path(order)
   end
 
-  # rubocop:disable Metrics/AbcSize
   def edit
     @order = Order.includes(order_details: :item).find(params[:id])
-
-    if current_user.can_edit_order?(@order)
-      if Rails.root.join("app/views/orders/status/#{@order.status}.html.erb").exist?
-        render "orders/status/#{@order.status}"
-      end
-    elsif current_user.can_view_order?(@order)
-      render :show
-    else
-      redirect_to orders_path
-    end
+    determine_edit_view
   end
-  # rubocop:enable Metrics/AbcSize
 
   def update
     order = current_user.update_order params
@@ -58,5 +47,19 @@ class OrdersController < ApplicationController
   def sync
     order = current_user.sync_order(params)
     redirect_to edit_order_path(order)
+  end
+
+  private
+
+  def determine_edit_view
+    if current_user.can_edit_order?(@order)
+      if Rails.root.join("app/views/orders/status/#{@order.status}.html.erb").exist?
+        render "orders/status/#{@order.status}"
+      end
+    elsif current_user.can_view_order?(@order)
+      render :show
+    else
+      redirect_to orders_path
+    end
   end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -41,6 +41,8 @@ class OrdersController < ApplicationController
       if Rails.root.join("app/views/orders/status/#{@order.status}.html.erb").exist?
         render "orders/status/#{@order.status}"
       end
+    elsif current_user.can_view_order?(@order)
+      render :show
     else
       redirect_to orders_path
     end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -56,10 +56,18 @@ class OrdersController < ApplicationController
       if Rails.root.join("app/views/orders/status/#{@order.status}.html.erb").exist?
         render "orders/status/#{@order.status}"
       end
-    elsif current_user.can_view_order?(@order)
-      render :show
     else
-      redirect_to orders_path
+      redirect_to order_path(@order)
     end
+  end
+
+  def show
+    @order = Order.includes(order_details: :item).find(params[:id])
+    redirect_to orders_path unless current_user.can_view_order?(@order)
+  end
+
+  def update
+    order = current_user.update_order params
+    redirect_to edit_order_path(order)
   end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -36,7 +36,18 @@ class OrdersController < ApplicationController
 
   def edit
     @order = Order.includes(order_details: :item).find(params[:id])
-    determine_edit_view
+    if current_user.can_edit_order?(@order)
+      render_status_or_edit
+    elsif current_user.can_view_order?(@order)
+      render :show
+    else
+      redirect_to orders_path
+    end
+  end
+
+  def show
+    @order = Order.includes(order_details: :item).find(params[:id])
+    redirect_to orders_path unless current_user.can_view_order?(@order)
   end
 
   def update
@@ -51,23 +62,11 @@ class OrdersController < ApplicationController
 
   private
 
-  def determine_edit_view
-    if current_user.can_edit_order?(@order)
-      if Rails.root.join("app/views/orders/status/#{@order.status}.html.erb").exist?
-        render "orders/status/#{@order.status}"
-      end
+  def render_status_or_edit
+    if Rails.root.join("app/views/orders/status/#{@order.status}.html.erb").exist?
+      render "orders/status/#{@order.status}"
     else
-      redirect_to order_path(@order)
+      render :edit
     end
-  end
-
-  def show
-    @order = Order.includes(order_details: :item).find(params[:id])
-    redirect_to orders_path unless current_user.can_view_order?(@order)
-  end
-
-  def update
-    order = current_user.update_order params
-    redirect_to edit_order_path(order)
   end
 end

--- a/app/models/concerns/users/order_manipulator.rb
+++ b/app/models/concerns/users/order_manipulator.rb
@@ -18,6 +18,10 @@ module Users
       can_sync_orders? && order.closed? && !order.synced?
     end
 
+    def can_view_order?(order)
+      super_admin? || member_at?(order.organization)
+    end
+
     def can_edit_order_at?(organization)
       super_admin? || member_at?(organization)
     end

--- a/app/views/orders/_order_info.html.erb
+++ b/app/views/orders/_order_info.html.erb
@@ -33,6 +33,6 @@
 
   <div class="form-group">
     <label class="control-label" for="order_notes">Notes:</label>
-    <%= text_area :order, :notes, class: 'form-control' %>
+    <%= text_area :order, :notes, class: 'form-control', disabled: !current_user.can_edit_order?(order) %>
   </div>
 <% end %>

--- a/app/views/orders/_tracking_detail_info.html.erb
+++ b/app/views/orders/_tracking_detail_info.html.erb
@@ -28,9 +28,11 @@
     </tr>
   </script>
 
-  <%= render partial: "tracking_details/tracking_detail_table", locals: { tracking_details: order.tracking_details, hidden: order.tracking_details.empty? } %>
+  <%= render partial: "tracking_details/tracking_detail_table", locals: { order: order, tracking_details: order.tracking_details, hidden: order.tracking_details.empty? } %>
 
-  <%= link_to "Add Tracking", nil, type: "button", class: "btn btn-default", id: "add-tracking-number" %>
+  <% if current_user.can_edit_order?(order) %>
+    <%= link_to "Add Tracking", nil, type: "button", class: "btn btn-default", id: "add-tracking-number" %>
 
-  <%= link_to "Hand Delivered", order_path(order, order: { tracking_details: { tracking_number: ["N/A"], shipping_carrier: [TrackingDetail.shipping_carriers["Hand"]] } }), method: :put, class: "btn btn-default" %>
+    <%= link_to "Hand Delivered", order_path(order, order: { tracking_details: { tracking_number: ["N/A"], shipping_carrier: [TrackingDetail.shipping_carriers["Hand"]] } }), method: :put, class: "btn btn-default" %>
+  <% end %>
 <% end %>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -1,0 +1,9 @@
+<% content_for :title, "Order #{@order.id}" %>
+
+<% content_for :content do %>
+  <div class="hidden-print">
+    <h4>Status: <b><%= @order.status.titleize %></b></h4>
+    <%= render partial: "order_header", locals: { order: @order } %>
+    <%= render partial: "order_table", locals: { order: @order, include_sku: true } %>
+  </div>
+<% end %>

--- a/app/views/tracking_details/_tracking_detail_table.html.erb
+++ b/app/views/tracking_details/_tracking_detail_table.html.erb
@@ -20,14 +20,16 @@
           <%= shipment.delivery_date %>
         </td>
         <td>
-          <% if shipment.delivery_date.blank? %>
-            <%= link_to tracking_detail_path(shipment, status: 'delivered'), method: :patch, class: 'btn btn-success btn-xs' do %>
-              <i class="glyphicon glyphicon-check"></i> Mark Delivered
+          <% if current_user.can_edit_order?(order) %>
+            <% if shipment.delivery_date.blank?%>
+              <%= link_to tracking_detail_path(shipment, status: 'delivered'), method: :patch, class: 'btn btn-success btn-xs' do %>
+                <i class="glyphicon glyphicon-check"></i> Mark Delivered
+              <% end %>
             <% end %>
-          <% end %>
 
-          <%= link_to tracking_detail_path(shipment), method: :delete, class: "btn btn-danger btn-xs", data: confirm(title: "Deleting Tracking Number: #{shipment.tracking_number}") do %>
-            <span class="glyphicon glyphicon-trash"></span>
+            <%= link_to tracking_detail_path(shipment), method: :delete, class: "btn btn-danger btn-xs", data: confirm(title: "Deleting Tracking Number: #{shipment.tracking_number}") do %>
+              <span class="glyphicon glyphicon-trash"></span>
+            <% end %>
           <% end %>
         </td>
       </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,7 +61,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :orders, only: %i[index new create edit update] do
+  resources :orders, except: %i[destroy] do
     collection do
       get :rejected, :closed, :canceled
     end

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -1,4 +1,0 @@
-require "rails_helper"
-
-describe OrdersController, type: :controller do
-end

--- a/spec/fixtures/orders.yml
+++ b/spec/fixtures/orders.yml
@@ -47,3 +47,23 @@ received_order_with_order_details:
   status: 5
   ship_to_name: "Acme Receiver"
   ship_to_address: "123 Fake St."
+
+acme_order:
+  organization: acme
+  user: acme_root
+  order_date: <%= Time.zone.now %>
+  created_at: <%= Time.zone.now %>
+  updated_at: <%= Time.zone.now %>
+  status: -1
+  ship_to_name: "Unsubmitted Order Receiver"
+  ship_to_address: "123 Fake St."
+
+acme_submitted_order:
+  organization: acme
+  user: acme_root
+  order_date: <%= Time.zone.now %>
+  created_at: <%= Time.zone.now %>
+  updated_at: <%= Time.zone.now %>
+  status: 1
+  ship_to_name: "Open Order Receiver"
+  ship_to_address: "123 Fake St."

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -65,4 +65,71 @@ describe User, type: :model do
       expect(foo_inc_root.member_at?(acme)).to be_falsey
     end
   end
+
+  describe "User::OrderManipulator" do
+    describe "#can_edit_order?" do
+      context "when order has not been shipped" do
+        let(:order) { orders(:acme_order) }
+        it "permits super_admin to edit" do
+          expect(root.can_edit_order?(order)).to be_truthy
+        end
+        it "permits acme_root to edit" do
+          expect(acme_root.can_edit_order?(order)).to be_truthy
+        end
+        it "permits acme_normal to edit" do
+          expect(acme_normal.can_edit_order?(order)).to be_truthy
+        end
+        it "denies non-org users to edit" do
+          expect(foo_inc_root.can_edit_order?(order)).to be_falsy
+        end
+      end
+      context "when order has been shipped" do
+        let(:order) { orders(:acme_submitted_order) }
+        it "permits super_admin to edit" do
+          expect(root.can_edit_order?(order)).to be_truthy
+        end
+        it "denies acme_root to edit" do
+          expect(acme_root.can_edit_order?(order)).to be_falsy
+        end
+        it "denies acme_normal to edit" do
+          expect(acme_normal.can_edit_order?(order)).to be_falsy
+        end
+        it "denies non-org users to edit" do
+          expect(foo_inc_root.can_edit_order?(order)).to be_falsy
+        end
+      end
+    end
+    describe "#can_view_order?" do
+      context "when order has not been shipped" do
+        let(:order) { orders(:acme_order) }
+        it "permits super_admin to view" do
+          expect(root.can_view_order?(order)).to be_truthy
+        end
+        it "permits acme_root to view" do
+          expect(acme_root.can_view_order?(order)).to be_truthy
+        end
+        it "permits acme_normal to view" do
+          expect(acme_normal.can_view_order?(order)).to be_truthy
+        end
+        it "denies non-org users to view" do
+          expect(foo_inc_root.can_view_order?(order)).to be_falsy
+        end
+      end
+      context "when order has been shipped" do
+        let(:order) { orders(:acme_submitted_order) }
+        it "permits super_admin to view" do
+          expect(root.can_view_order?(order)).to be_truthy
+        end
+        it "denies acme_root to view" do
+          expect(acme_root.can_view_order?(order)).to be_truthy
+        end
+        it "denies acme_normal to view" do
+          expect(acme_normal.can_view_order?(order)).to be_truthy
+        end
+        it "denies non-org users to view" do
+          expect(foo_inc_root.can_view_order?(order)).to be_falsy
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/orders_controller_request_spec.rb
+++ b/spec/requests/orders_controller_request_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+describe OrdersController, type: :request do
+  let(:root) { users(:root) }
+  let(:org_admin) { users(:view_check_root) }
+  let(:org_user) { users(:view_check_normal) }
+  let(:non_org_user) { users(:foo_inc_root) }
+
+  describe "#edit" do
+    context "before order has been submitted" do
+      let(:order) { orders(:view_check_unsubmitted_order) }
+      subject { get edit_order_path(order) }
+
+      context "when logged in as super_admin" do
+        before { sign_in root }
+        it "confirm order view is shown" do
+          expect(subject).to render_template("orders/status/confirm_order")
+        end
+      end
+
+      context "when logged in as order's organization admin user" do
+        before { sign_in org_admin }
+        it "confirm order view is shown" do
+          expect(subject).to render_template("orders/status/confirm_order")
+        end
+      end
+
+      context "when logged in as order's organization normal user" do
+        before { sign_in org_user }
+        it "confirm order view is shown" do
+          expect(subject).to render_template("orders/status/confirm_order")
+        end
+      end
+
+      context "when logged in as another organization user" do
+        before { sign_in non_org_user }
+        it "redirects to orders index" do
+          expect(subject).to redirect_to(orders_path)
+        end
+      end
+    end
+
+    context "after order has been submitted" do
+      let(:order) { orders(:view_check_submitted_order) }
+      subject { get edit_order_path(order) }
+
+      context "when logged in as super_admin" do
+        before { sign_in root }
+        it "edit view is shown" do
+          expect(subject).to render_template("edit")
+        end
+      end
+
+      context "when logged in as order's organization admin user" do
+        before { sign_in org_admin }
+        it "show view is shown" do
+          expect(subject).to render_template("show")
+        end
+      end
+
+      context "when logged in as order's organization normal user" do
+        before { sign_in org_user }
+        it "show view is shown" do
+          expect(subject).to render_template("show")
+        end
+      end
+
+      context "when logged in as another organization user" do
+        before { sign_in non_org_user }
+        it "redirects to orders index" do
+          expect(subject).to redirect_to(orders_path)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/orders_controller_request_spec.rb
+++ b/spec/requests/orders_controller_request_spec.rb
@@ -34,8 +34,8 @@ describe OrdersController, type: :request do
 
       context "when logged in as another organization user" do
         before { sign_in non_org_user }
-        it "redirects to orders index" do
-          expect(subject).to redirect_to(orders_path)
+        it "redirects to order show" do
+          expect(subject).to redirect_to(order_path(order))
         end
       end
     end
@@ -53,23 +53,56 @@ describe OrdersController, type: :request do
 
       context "when logged in as order's organization admin user" do
         before { sign_in org_admin }
-        it "show view is shown" do
-          expect(subject).to render_template("show")
+        it "redirects to order show" do
+          expect(subject).to redirect_to(order_path(order))
         end
       end
 
       context "when logged in as order's organization normal user" do
         before { sign_in org_user }
-        it "show view is shown" do
-          expect(subject).to render_template("show")
+        it "redirects to order show" do
+          expect(subject).to redirect_to(order_path(order))
         end
       end
 
       context "when logged in as another organization user" do
         before { sign_in non_org_user }
-        it "redirects to orders index" do
-          expect(subject).to redirect_to(orders_path)
+        it "redirects to order show" do
+          expect(subject).to redirect_to(order_path(order))
         end
+      end
+    end
+  end
+
+  describe "#show" do
+    let(:order) { orders(:view_check_submitted_order) }
+    subject { get order_path(order) }
+
+    context "when logged in as super_admin" do
+      before { sign_in root }
+      it "show view is shown" do
+        expect(subject).to render_template("show")
+      end
+    end
+
+    context "when logged in as order's organization admin user" do
+      before { sign_in org_admin }
+      it "show view is shown" do
+        expect(subject).to render_template("show")
+      end
+    end
+
+    context "when logged in as order's organization normal user" do
+      before { sign_in org_user }
+      it "redirects to order show" do
+        expect(subject).to render_template("show")
+      end
+    end
+
+    context "when logged in as another organization user" do
+      before { sign_in non_org_user }
+      it "redirects to order show" do
+        expect(subject).to redirect_to(orders_path)
       end
     end
   end


### PR DESCRIPTION
Addresses: #750 

This commit fixes a problem where non-super-admins cannot view an order once it's been submitted.

![view order instead of edit](https://user-images.githubusercontent.com/363583/103099909-e6f37e80-45d5-11eb-8342-80e32b67734a.jpg)
