### PR TITLE
Small fixes for inventory reconciliations

### DIFF
--- a/app/helpers/reconciliations_helper.rb
+++ b/app/helpers/reconciliations_helper.rb
@@ -15,9 +15,9 @@ module ReconciliationsHelper
     return unless delta.changed_amount?
 
     if delta.changed_amount > 0
-      tag(:i, class: "glyphicon glyphicon-triangle-top")
+      content_tag(:i, "", class: "glyphicon glyphicon-triangle-top")
     else
-      tag(:i, class: "glyphicon glyphicon-triangle-bottom")
+      content_tag(:i, "", class: "glyphicon glyphicon-triangle-bottom")
     end
   end
 end

--- a/app/models/reconciliation_deltas.rb
+++ b/app/models/reconciliation_deltas.rb
@@ -87,11 +87,6 @@ class ReconciliationDeltas
         "text-danger"
       end
     end
-
-    def changed_amount_icon
-      return unless changed_amount?
-      changed_amount > 0 ? "top" : "bottom"
-    end
   end
 
   class CompletedDelta

--- a/app/views/inventory_reconciliations/_completed_deltas.html.erb
+++ b/app/views/inventory_reconciliations/_completed_deltas.html.erb
@@ -18,7 +18,7 @@
             <td><%= delta.final_count %></td>
 
             <td class="<%= delta.changed_amount_css_class %>">
-              <%= delta.changed_amount_icon %>
+              <%= changed_amount_icon(delta) %>
               <%= delta.changed_amount %>
             </td>
           </tr>

--- a/app/views/inventory_reconciliations/_incomplete_deltas.html.erb
+++ b/app/views/inventory_reconciliations/_incomplete_deltas.html.erb
@@ -19,7 +19,7 @@
 
       <tbody>
         <% @reconciliation.deltas.each do |delta| %>
-          <% reconciliation_delta_table_row(delta) do %>
+          <%= reconciliation_delta_table_row(delta) do %>
             <td class="<%= delta.description_css_class %>">
               <%= delta.item.category.description %> - <%= delta.item.description %>
             </td>


### PR DESCRIPTION
Incomplete deltas was not rendering due to missing "=".
Use helper method everywhere to get proper icons and whatnot.
Fix helper method to use i tag with as a content_tag to ensure <i></i> instead of the incorrect <i/>.